### PR TITLE
Removed deprecated ABAddressBookCreate()

### DIFF
--- a/ABAddressBook.m
+++ b/ABAddressBook.m
@@ -110,7 +110,7 @@ static void _ExternalChangeCallback( ABAddressBookRef bookRef, CFDictionaryRef i
 
 - (id) init
 {
-    ABAddressBookRef ref = ABAddressBookCreate();
+    ABAddressBookRef ref = ABAddressBookCreateWithOptions(NULL, NULL);
     
 	self = [self initWithABRef:ref];
 	

--- a/iPhoneContacts.xcodeproj/project.pbxproj
+++ b/iPhoneContacts.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 45;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -176,8 +176,11 @@
 /* Begin PBXProject section */
 		0867D690FE84028FC02AAC07 /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0460;
+			};
 			buildConfigurationList = 1DEB922208733DC00010E9CD /* Build configuration list for PBXProject "iPhoneContacts" */;
-			compatibilityVersion = "Xcode 3.1";
+			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 1;
 			knownRegions = (
@@ -219,7 +222,6 @@
 				COPY_PHASE_STRIP = NO;
 				DSTROOT = /tmp/iPhoneContacts.dst;
 				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_ENABLE_FIX_AND_CONTINUE = YES;
 				GCC_MODEL_TUNING = G5;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -252,7 +254,6 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				OTHER_LDFLAGS = "-ObjC";
-				PREBINDING = NO;
 				SDKROOT = iphoneos;
 			};
 			name = Debug;
@@ -265,7 +266,6 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				OTHER_LDFLAGS = "-ObjC";
-				PREBINDING = NO;
 				SDKROOT = iphoneos;
 			};
 			name = Release;


### PR DESCRIPTION
ABAddressBookCreate() has been deprecated in iOS 6. I have updated it with ABAddressBookCreateWithOptions.
